### PR TITLE
feat: add ranking pages and components for NFT creators and minters #26

### DIFF
--- a/app/(ranking)/ranking/creator/page.tsx
+++ b/app/(ranking)/ranking/creator/page.tsx
@@ -1,0 +1,153 @@
+import Leaderboard from '@/containers/ranking/leaderboard'
+
+const creatorData = {
+  today: [
+    {
+      id: 1,
+      name: 'Jaydon Ekstrom Bothman',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 1.41,
+      itemsSold: 602,
+      volume: 12.4
+    },
+    {
+      id: 2,
+      name: 'Ruben Carder',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 1.41,
+      itemsSold: 602,
+      volume: 12.4
+    },
+    {
+      id: 3,
+      name: 'Alfredo Septimus',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 1.41,
+      itemsSold: 602,
+      volume: 12.4
+    },
+    {
+      id: 4,
+      name: 'Davis Franci',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 1.41,
+      itemsSold: 602,
+      volume: 12.4
+    }
+  ],
+  week: [
+    {
+      id: 1,
+      name: 'Ruben Carder',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 2.15,
+      itemsSold: 875,
+      volume: 18.2
+    },
+    {
+      id: 2,
+      name: 'Jaydon Ekstrom Bothman',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 1.89,
+      itemsSold: 710,
+      volume: 15.8
+    },
+    {
+      id: 3,
+      name: 'Davis Franci',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 1.63,
+      itemsSold: 645,
+      volume: 13.9
+    },
+    {
+      id: 4,
+      name: 'Alfredo Septimus',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 1.41,
+      itemsSold: 590,
+      volume: 12.4
+    }
+  ],
+  month: [
+    {
+      id: 1,
+      name: 'Alfredo Septimus',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 3.28,
+      itemsSold: 1245,
+      volume: 28.5
+    },
+    {
+      id: 2,
+      name: 'Davis Franci',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 2.94,
+      itemsSold: 1100,
+      volume: 24.8
+    },
+    {
+      id: 3,
+      name: 'Ruben Carder',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 2.67,
+      itemsSold: 980,
+      volume: 21.2
+    },
+    {
+      id: 4,
+      name: 'Jaydon Ekstrom Bothman',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 2.35,
+      itemsSold: 875,
+      volume: 19.5
+    }
+  ],
+  all: [
+    {
+      id: 1,
+      name: 'Davis Franci',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 5.32,
+      itemsSold: 2450,
+      volume: 45.8
+    },
+    {
+      id: 2,
+      name: 'Alfredo Septimus',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 4.85,
+      itemsSold: 2100,
+      volume: 38.2
+    },
+    {
+      id: 3,
+      name: 'Ruben Carder',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 4.25,
+      itemsSold: 1850,
+      volume: 32.4
+    },
+    {
+      id: 4,
+      name: 'Jaydon Ekstrom Bothman',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 3.98,
+      itemsSold: 1620,
+      volume: 28.9
+    }
+  ]
+}
+
+export default function CreatorRankingPage() {
+  return (
+    <main className='min-h-screen'>
+      <Leaderboard
+        title='Top Creators'
+        description='Check out top ranking NFT artists on the NFT Marketplace.'
+        itemLabel='NFTs Sold'
+        data={creatorData}
+      />
+    </main>
+  )
+}

--- a/app/(ranking)/ranking/minter/page.tsx
+++ b/app/(ranking)/ranking/minter/page.tsx
@@ -1,0 +1,153 @@
+import Leaderboard from '@/containers/ranking/leaderboard'
+
+const minterData = {
+  today: [
+    {
+      id: 1,
+      name: 'Alice Johnson',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 2.5,
+      itemsSold: 15,
+      volume: 3.2
+    },
+    {
+      id: 2,
+      name: 'Bob Smith',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 1.8,
+      itemsSold: 12,
+      volume: 2.8
+    },
+    {
+      id: 3,
+      name: 'Charlie Brown',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 1.2,
+      itemsSold: 10,
+      volume: 2.1
+    },
+    {
+      id: 4,
+      name: 'Diana Prince',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 0.9,
+      itemsSold: 8,
+      volume: 1.7
+    }
+  ],
+  week: [
+    {
+      id: 1,
+      name: 'Bob Smith',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 5.2,
+      itemsSold: 45,
+      volume: 9.8
+    },
+    {
+      id: 2,
+      name: 'Alice Johnson',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 4.7,
+      itemsSold: 40,
+      volume: 8.5
+    },
+    {
+      id: 3,
+      name: 'Diana Prince',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 3.9,
+      itemsSold: 35,
+      volume: 7.2
+    },
+    {
+      id: 4,
+      name: 'Charlie Brown',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 3.1,
+      itemsSold: 30,
+      volume: 6.4
+    }
+  ],
+  month: [
+    {
+      id: 1,
+      name: 'Charlie Brown',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 12.5,
+      itemsSold: 150,
+      volume: 32.5
+    },
+    {
+      id: 2,
+      name: 'Diana Prince',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 11.2,
+      itemsSold: 135,
+      volume: 28.9
+    },
+    {
+      id: 3,
+      name: 'Alice Johnson',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 10.1,
+      itemsSold: 120,
+      volume: 25.7
+    },
+    {
+      id: 4,
+      name: 'Bob Smith',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 9.3,
+      itemsSold: 110,
+      volume: 23.6
+    }
+  ],
+  all: [
+    {
+      id: 1,
+      name: 'Diana Prince',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 25.8,
+      itemsSold: 520,
+      volume: 112.4
+    },
+    {
+      id: 2,
+      name: 'Charlie Brown',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 23.5,
+      itemsSold: 480,
+      volume: 103.6
+    },
+    {
+      id: 3,
+      name: 'Bob Smith',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 21.7,
+      itemsSold: 450,
+      volume: 97.2
+    },
+    {
+      id: 4,
+      name: 'Alice Johnson',
+      avatar: '/placeholder.svg?height=40&width=40',
+      change: 20.1,
+      itemsSold: 420,
+      volume: 90.7
+    }
+  ]
+}
+
+export default function MinterRankingPage() {
+  return (
+    <main className='min-h-screen py-12'>
+      <Leaderboard
+        title='Top Minters'
+        description="See who's minting the most NFTs on our platform."
+        itemLabel='NFTs Minted'
+        data={minterData}
+      />
+    </main>
+  )
+}

--- a/app/(ranking)/ranking/page.tsx
+++ b/app/(ranking)/ranking/page.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import Link from 'next/link'
+import { motion } from 'framer-motion'
+import { Card, CardContent } from '@/components/ui/card'
+import { BarChartIcon as ChartBar, Users } from 'lucide-react'
+
+function RankingPage() {
+  const containerVariants = {
+    hidden: { opacity: 0 },
+    visible: {
+      opacity: 1,
+      transition: {
+        staggerChildren: 0.1
+      }
+    }
+  }
+
+  const itemVariants = {
+    hidden: { y: 20, opacity: 0 },
+    visible: {
+      y: 0,
+      opacity: 1
+    }
+  }
+
+  return (
+    <div className='flex flex-col items-center justify-center p-4'>
+      <motion.div className='w-full max-w-4xl' variants={containerVariants} initial='hidden' animate='visible'>
+        <motion.h1 className='mb-10 text-center text-4xl font-bold tracking-tight' variants={itemVariants}>
+          0xpenGuild Rankings
+        </motion.h1>
+        <div className='grid grid-cols-1 gap-8 sm:grid-cols-2'>
+          <motion.div variants={itemVariants}>
+            <Link href='/ranking/creator' className='block h-full'>
+              <Card className='h-full transition-all hover:-translate-y-1'>
+                <CardContent className='flex h-64 flex-col items-center justify-center p-6'>
+                  <ChartBar className='mb-4 h-16 w-16 text-primary' />
+                  <h2 className='mb-2 text-2xl font-semibold'>Creator Rankings</h2>
+                  <p className='text-center text-muted-foreground'>Discover top NFT creators and their achievements</p>
+                </CardContent>
+              </Card>
+            </Link>
+          </motion.div>
+          <motion.div variants={itemVariants}>
+            <Link href='/ranking/minter' className='block h-full'>
+              <Card className='h-full transition-all hover:-translate-y-1'>
+                <CardContent className='flex h-64 flex-col items-center justify-center p-6'>
+                  <Users className='mb-4 h-16 w-16 text-primary' />
+                  <h2 className='mb-2 text-2xl font-semibold'>Minter Rankings</h2>
+                  <p className='text-center text-muted-foreground'>See who's leading the pack in NFT minting</p>
+                </CardContent>
+              </Card>
+            </Link>
+          </motion.div>
+        </div>
+      </motion.div>
+    </div>
+  )
+}
+
+export default RankingPage

--- a/components/layouts/header.tsx
+++ b/components/layouts/header.tsx
@@ -5,12 +5,12 @@ import StartHighlight from '@/components/start-highlight'
 import { ThemeToggle } from '@/components/theme-toggle'
 import { Separator } from '@/components/ui/separator'
 import { IconArrowRight, IconBrandDiscordFilled, IconBrandTelegram, IconBrandX, IconMenu2 } from '@tabler/icons-react'
-import Image from 'next/image'
 import Link from 'next/link'
 import { useState } from 'react'
 
 const MENU_ITEMS = [
   { label: 'Culture', href: '/culture' },
+  { label: 'Ranking', href: '/ranking' },
   { label: 'Roadmap', href: '/roadmap' }
 ]
 

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import * as React from "react"
+import * as AvatarPrimitive from "@radix-ui/react-avatar"
+
+import { cn } from "@/lib/utils"
+
+const Avatar = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
+      className
+    )}
+    {...props}
+  />
+))
+Avatar.displayName = AvatarPrimitive.Root.displayName
+
+const AvatarImage = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Image
+    ref={ref}
+    className={cn("aspect-square h-full w-full", className)}
+    {...props}
+  />
+))
+AvatarImage.displayName = AvatarPrimitive.Image.displayName
+
+const AvatarFallback = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Fallback
+    ref={ref}
+    className={cn(
+      "flex h-full w-full items-center justify-center rounded-full bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName
+
+export { Avatar, AvatarImage, AvatarFallback }

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/containers/ranking/leaderboard.tsx
+++ b/containers/ranking/leaderboard.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+interface LeaderboardItem {
+  id: number
+  name: string
+  avatar: string
+  change: number
+  itemsSold: number
+  volume: number
+}
+
+interface LeaderboardProps {
+  title: string
+  description: string
+  itemLabel: string
+  data: {
+    today: LeaderboardItem[]
+    week: LeaderboardItem[]
+    month: LeaderboardItem[]
+    all: LeaderboardItem[]
+  }
+}
+
+const LeaderList = ({ items, itemLabel }: { items: LeaderboardItem[]; itemLabel: string }) => (
+  <Card>
+    <CardHeader>
+      <CardTitle>
+        <div className='grid grid-cols-12 gap-4 text-sm text-muted-foreground'>
+          <div className='col-span-6 flex items-center'>
+            <span className='w-8'>#</span>
+            Name
+          </div>
+          <div className='col-span-2 text-right'>Change</div>
+          <div className='col-span-2 text-right'>{itemLabel}</div>
+          <div className='col-span-2 text-right'>Volume</div>
+        </div>
+      </CardTitle>
+    </CardHeader>
+    <CardContent>
+      {items.map((item) => (
+        <div key={item.id} className='grid grid-cols-12 items-center gap-4 border-t py-4'>
+          <div className='col-span-6 flex items-center gap-4'>
+            <span className='w-8 text-base text-muted-foreground'>{item.id}</span>
+            <Avatar className='h-10 w-10'>
+              <AvatarImage src={item.avatar} alt={item.name} />
+              <AvatarFallback>
+                {item.name
+                  .split(' ')
+                  .map((n) => n[0])
+                  .join('')}
+              </AvatarFallback>
+            </Avatar>
+            <span className='text-base font-medium'>{item.name}</span>
+          </div>
+          <div className='col-span-2 text-right text-base text-highlight'>+{item.change}%</div>
+          <div className='col-span-2 text-right text-base tabular-nums'>{item.itemsSold}</div>
+          <div className='col-span-2 text-right text-base tabular-nums'>{item.volume} ETH</div>
+        </div>
+      ))}
+    </CardContent>
+  </Card>
+)
+
+export default function Leaderboard({ title, description, itemLabel, data }: LeaderboardProps) {
+  return (
+    <div className='mx-auto w-full max-w-6xl p-6'>
+      <div className='space-y-6'>
+        <h2 className='text-3xl font-bold tracking-tight'>{title}</h2>
+        <p className='text-xl text-muted-foreground'>{description}</p>
+      </div>
+
+      <Tabs defaultValue='today' className='mt-12'>
+        <TabsList className='mb-8 grid w-full max-w-[400px] grid-cols-4'>
+          <TabsTrigger value='today'>Today</TabsTrigger>
+          <TabsTrigger value='week'>This Week</TabsTrigger>
+          <TabsTrigger value='month'>This Month</TabsTrigger>
+          <TabsTrigger value='all'>All Time</TabsTrigger>
+        </TabsList>
+        <TabsContent value='today'>
+          <LeaderList items={data.today} itemLabel={itemLabel} />
+        </TabsContent>
+        <TabsContent value='week'>
+          <LeaderList items={data.week} itemLabel={itemLabel} />
+        </TabsContent>
+        <TabsContent value='month'>
+          <LeaderList items={data.month} itemLabel={itemLabel} />
+        </TabsContent>
+        <TabsContent value='all'>
+          <LeaderList items={data.all} itemLabel={itemLabel} />
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.2.2",
+        "@radix-ui/react-avatar": "^1.1.2",
         "@radix-ui/react-dialog": "^1.1.4",
         "@radix-ui/react-select": "^2.1.2",
         "@radix-ui/react-separator": "^1.1.0",
         "@radix-ui/react-slider": "^1.2.2",
         "@radix-ui/react-slot": "^1.1.0",
+        "@radix-ui/react-tabs": "^1.1.2",
         "@radix-ui/react-toast": "^1.2.4",
         "@rainbow-me/rainbowkit": "^2.2.1",
         "@tabler/icons-react": "^3.24.0",
@@ -1994,6 +1996,88 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-avatar": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.2.tgz",
+      "integrity": "sha512-GaC7bXQZ5VgZvVvsJ5mu/AEbjYLnhhkoidOboC50Z6FFlLA03wG2ianUoH+zgDQ31/9gCF59bE4+2bBgTyMiig==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz",
+      "integrity": "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.1.tgz",
+      "integrity": "sha512-sHCWTtxwNn3L3fH8qAfnF3WbUZycW93SM1j3NFDzXBiz8D6F5UTTy8G1+WFEaiCdvCVRJWj6N2R4Xq6HdiHmDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.1.tgz",
+      "integrity": "sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-collapsible": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.2.tgz",
@@ -2564,6 +2648,125 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.1.tgz",
+      "integrity": "sha512-QE1RoxPGJ/Nm8Qmk0PxP8ojmoaS67i0s7hVssS7KuI2FQoc/uzVlZsqKfQvxPE6D8hICCPHJ4D88zNhT3OOmkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-collection": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.1.tgz",
+      "integrity": "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.1.tgz",
+      "integrity": "sha512-LwT3pSho9Dljg+wY2KN2mrrh6y3qELfftINERIzBUO9e0N+t0oMTyn3k9iv+ZqgrwGkRnLpNJrsMv9BZlt2yuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-slot": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz",
+      "integrity": "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.1.tgz",
+      "integrity": "sha512-sHCWTtxwNn3L3fH8qAfnF3WbUZycW93SM1j3NFDzXBiz8D6F5UTTy8G1+WFEaiCdvCVRJWj6N2R4Xq6HdiHmDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.1.tgz",
+      "integrity": "sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-select": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.1.2.tgz",
@@ -2783,6 +2986,98 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.2.tgz",
+      "integrity": "sha512-9u/tQJMcC2aGq7KXpGivMm1mgq7oRJKXphDwdypPd/j21j/2znamPU8WkXgnhUaTrSFNIt8XhOyCAupg8/GbwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-roving-focus": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.1.tgz",
+      "integrity": "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz",
+      "integrity": "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.1.tgz",
+      "integrity": "sha512-sHCWTtxwNn3L3fH8qAfnF3WbUZycW93SM1j3NFDzXBiz8D6F5UTTy8G1+WFEaiCdvCVRJWj6N2R4Xq6HdiHmDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.1.tgz",
+      "integrity": "sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -10,11 +10,13 @@
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.2",
+    "@radix-ui/react-avatar": "^1.1.2",
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-select": "^2.1.2",
     "@radix-ui/react-separator": "^1.1.0",
     "@radix-ui/react-slider": "^1.2.2",
     "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-tabs": "^1.1.2",
     "@radix-ui/react-toast": "^1.2.4",
     "@rainbow-me/rainbowkit": "^2.2.1",
     "@tabler/icons-react": "^3.24.0",


### PR DESCRIPTION
- Introduced new ranking pages for creators and minters, featuring a leaderboard with dynamic data.
- Added a new `RankingPage` component to display overall rankings.
- Created `CreatorRankingPage` and `MinterRankingPage` components to showcase top performers with detailed statistics.
- Implemented a reusable `Leaderboard` component to handle ranking data presentation.
- Updated package dependencies to include new Radix UI components for avatar and tabs functionality.
- Enhanced the layout by adding a link to the ranking section in the header.