### PR TITLE
feat: add @next/third-parties dependency and integrate Google Analytics

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,4 @@
+import { GoogleAnalytics } from '@next/third-parties/google'
 import type { Metadata } from 'next'
 import Header from '@/components/layouts/header'
 import localFont from 'next/font/local'
@@ -62,6 +63,7 @@ export default function RootLayout({
           <main className='flex flex-col gap-2 py-14'>{children}</main>
         </Providers>
       </body>
+      <GoogleAnalytics gaId='G-QNXHRV4MHW' />
     </html>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "swap-token",
       "version": "0.1.0",
       "dependencies": {
+        "@next/third-parties": "^15.1.3",
         "@radix-ui/react-accordion": "^1.2.2",
         "@radix-ui/react-avatar": "^1.1.2",
         "@radix-ui/react-dialog": "^1.1.4",
@@ -1386,6 +1387,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-15.1.3.tgz",
+      "integrity": "sha512-nz2mthh08xMRgNKRA+Z7lM1BqHqukGcFyu5z0nXFo3/KXsBgaPJkfnkfebw/YTqkxryV+aEttf/iAWDB6dUO6A==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@noble/ciphers": {
@@ -11219,6 +11233,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/thread-stream": {
       "version": "0.15.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@next/third-parties": "^15.1.3",
     "@radix-ui/react-accordion": "^1.2.2",
     "@radix-ui/react-avatar": "^1.1.2",
     "@radix-ui/react-dialog": "^1.1.4",


### PR DESCRIPTION
- Added @next/third-parties package (version 15.1.3) to package.json and package-lock.json.
- Imported GoogleAnalytics component from @next/third-parties in layout.tsx.
- Integrated Google Analytics with the specified GA ID in the RootLayout component.